### PR TITLE
Replace ytop with bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Harness the power of Rust. Those fast productivity tools created by using Rust.
 
 ## System Monitor
 
-* [ytop](https://github.com/cjbassi/ytop) — A TUI system monitor written in Rust.
+* [bottom](https://github.com/ClementTsang/bottom) — A customizable cross-platform graphical process/system monitor for the terminal.
 * [procs](https://github.com/dalance/procs) — **procs** is a replacement for `ps` written in [Rust](https://www.rust-lang.org/).
 * [Zenith](https://github.com/bvaisvil/zenith) — Sort of like top or htop but with zoom-able charts, network, and disk usage.
 * [RustScan](https://github.com/RustScan/RustScan) — 🤖 The Modern Port Scanner 🤖 .


### PR DESCRIPTION
`ytop` is no longer being maintained, its README file suggests using `bottom` which is written in Rust as well:

<img width="932" alt="image" src="https://user-images.githubusercontent.com/2049686/233106444-c6d984af-50ee-4df7-b16c-3e93f98a3f70.png">
