### PR TITLE
Add Security section with n01d-forge and n01d-machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
   - [Dev-Utilities](#dev-utilities)
   - [Editor](#editor)
   - [Others](#others)
+  - [Security](#security)
 
 ## Search
 
@@ -185,5 +186,10 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
 - [youtube-tui](https://github.com/Siriusmart/youtube-tui) – An aesthetically pleasing YouTube TUI written in Rust.
 - [ytermusic](https://github.com/ccgauche/ytermusic) — An in terminal youtube music client with focus on privacy, simplicity and performance.
 - [zola](https://github.com/getzola/zola) — A fast static site generator in a single binary with everything built-in. https://www.getzola.org
+
+## Security
+
+- [n01d-forge](https://github.com/bad-antics/n01d-forge) — Native GUI image burner with LUKS/VeraCrypt encryption support for creating secure bootable drives.
+- [n01d-machine](https://github.com/bad-antics/n01d-machine) — Secure VM manager with Tor/VPN integration, sandbox isolation, and network compartmentalization.
 
 Thanks these authors.


### PR DESCRIPTION
## Description
Adds a new Security section with two Rust-based security tools.

## New Tools

### n01d-forge
- **Description**: Native GUI image burner with LUKS/VeraCrypt encryption support for creating secure bootable drives
- **GitHub**: https://github.com/bad-antics/n01d-forge
- **Built with**: Rust + egui

### n01d-machine
- **Description**: Secure VM manager with Tor/VPN integration, sandbox isolation, and network compartmentalization
- **GitHub**: https://github.com/bad-antics/n01d-machine
- **Built with**: Rust + egui

## Why Add Security Section?
The awesome-rust-tools list covers many categories but is missing security-focused tools. These two tools fill that gap by providing:
- Secure disk imaging with encryption
- Private/anonymous VM management

Both are native Rust applications using the egui GUI framework, fitting the theme of fast, productivity-focused Rust tools.