### PR TITLE
Add em-dee-pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
 
 - [bat](https://github.com/sharkdp/bat)— A `cat(1)` clone with wings.
 - [csvlens](https://github.com/YS-L/csvlens) — Command line csv viewer.
+- [em-dee-pdf](https://github.com/brendandebeasi/em-dee-pdf) — Convert Markdown files to styled PDFs with 18 built-in themes.
 - [hck](https://github.com/sstadick/hck) — A sharp cut(1) clone.
 - [hex](https://github.com/sitkevij/hex) — 🔮 Futuristic take on hexdump, made in Rust.
 - [hexyl](https://github.com/sharkdp/hexyl) — A command-line hex viewer.


### PR DESCRIPTION
## Add em-dee-pdf

[em-dee-pdf](https://github.com/brendandebeasi/em-dee-pdf) is a Rust CLI that converts Markdown files to styled PDFs with 18 built-in themes. Built with Typst as the typesetting engine.

Added to the **File** section.