### PR TITLE
Add Lateralus compiler to Dev-Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
 - [jaq](https://github.com/01mf02/jaq) — A jq clone focussed on correctness, speed, and simplicity.
 - [jj](https://github.com/martinvonz/jj) — A Git-compatible VCS that is both simple and powerful.
 - [jless](https://github.com/PaulJuliusMartinez/jless) — jless is a command-line JSON viewer designed for reading, exploring, and searching through JSON data.
+- [lateralus](https://github.com/bad-antics/lateralus-lang) — A pipeline-native programming language compiler with a register-based VM, C backend, LLVM and WASM targets, LSP, and bare-metal OS support.
 - [lurk](https://github.com/JakWai01/lurk) — A pretty (simple) alternative to strace.
 - [mask](https://github.com/jacobdeichert/mask) — 🎭 A CLI task runner defined by a simple markdown file.
 - [mise](https://github.com/jdx/mise) –  dev tools, env vars, task runner.


### PR DESCRIPTION
Adding [Lateralus](https://github.com/bad-antics/lateralus-lang) — a pipeline-native programming language compiler written in Rust with a register-based VM, C backend, LLVM and WASM targets, full LSP implementation, and bare-metal OS support. Features pattern matching, ADTs, type inference, and borrow checking.