### PR TITLE
Add remove-audio.com - free browser-based audio remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,3 +196,6 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
 - [n01d-machine](https://github.com/bad-antics/n01d-machine) — Secure VM manager with Tor/VPN integration, sandbox isolation, and network compartmentalization.
 
 Thanks these authors.
+
+
+* [Remove audio from video](https://remove-audio.com) - Free, browser-based audio remover. Local processing via WebAssembly. No signup, no watermarks. Batch up to 20 clips.


### PR DESCRIPTION
This adds https://remove-audio.com to the list.

It is a free, browser-based tool that strips audio from video files using FFmpeg.wasm and WebAssembly. All processing is local - no files are uploaded to any server. No signup, no watermarks, batch support for up to 20 clips.

Fits this list because: it is a free web tool for video processing.