### PR TITLE
Add qnote to Editor section

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
 - [iota](https://github.com/gchp/iota) — A terminal-based text editor written in Rust.
 - [lapce](https://github.com/lapce/lapce) — Lightning-fast and Powerful Code Editor written in Rust.
 - [neovide](https://github.com/Kethku/neovide) — No Nonsense Neovim Client in Rust.
+- [qnote](https://github.com/Omibranch/qnote) — Minimal frameless notepad for Linux with Markdown preview, PDF export via Typst, OCR via Tesseract, and version history. Built with Tauri 2.
 - [rnote](https://github.com/flxzt/rnote) — Sketch and take handwritten notes.
 - [TUI-Journal](https://github.com/AmmarAbouZor/tui-journal) — Your journal app if you live in a terminal.
 - [xi-editor](https://github.com/xi-editor/xi-editor) — A modern editor with a backend written in Rust.


### PR DESCRIPTION
Add [qnote](https://github.com/Omibranch/qnote) to the Editor section.

qnote is a minimal frameless notepad for Linux built with Tauri 2 (Rust + TypeScript). It features:

- Markdown editing with live preview
- Real PDF export via Typst
- OCR via Tesseract
- Automatic version history with snapshots
- Dark/light themes and custom fonts
- Available on AUR

Fits the list as a Rust-based GUI editor tool.