### PR TITLE
Add Reflex to Search section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
 - [television](https://github.com/alexpasmantier/television) — General purpose fuzzy finder TUI.
 - [skim](https://github.com/lotabout/skim) — Fuzzy Finder in rust!
 - [scout](https://github.com/jhbabon/scout) — Your friendly fuzzy finder.
+- [Reflex](https://github.com/reflex-search/reflex) — Local-first, trigram-indexed full-text code search engine for large codebases. Sub-100ms queries, JSON output, and MCP server for AI agent workflows.
 - [sweep-rs](https://github.com/aslpavel/sweep-rs) — Sweep is a tool for interactive search through a list of entries. It is inspired by fzf.
 
 ## FileSystem


### PR DESCRIPTION
## Description

Adds **Reflex** (`rfx`) to the **Search** section.

Reflex is a fast, local-first code search engine written in Rust. It builds a trigram-based inverted index (similar to Zoekt/Google Code Search) over your codebase and answers full-text queries in under 100ms — even across 10k+ files.

Why it belongs here alongside `fd`, `ripgrep`, and `skim`:
- Pure Rust, MIT licensed, actively maintained
- Persistent trigram index via memory-mapped I/O (`memmap2`, `rusqlite`)
- Incremental reindex using `blake3` content hashing
- `.gitignore` support via the `ignore` crate
- Runtime tree-sitter symbol parsing at query time (not at index time)
- JSON output and optional MCP server for AI coding agent integration

It's the Rust-native answer to "I need to search a large codebase quickly without sending my code to the cloud."