### PR TITLE
Add gity to Dev-Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
 - [gitlogue](https://github.com/unhappychoice/gitlogue) - A cinematic Git commit history replay for the terminal.
 - [gitoxide](https://github.com/Byron/gitoxide) — An idiomatic, lean, fast & safe pure Rust implementation of Git.
 - [gitui](https://github.com/extrawurst/gitui) — Blazing fast terminal-ui for git written in rust.
+- [gity](https://github.com/neul-labs/gity) — A cross-platform Rust daemon that accelerates Git on large repos via the fsmonitor protocol.
 - [gpg-tui](https://github.com/orhun/gpg-tui) – Manage your GnuPG keys with ease! 🔐.
 - [grex](https://github.com/pemistahl/grex) - A command-line tool and library for generating regular expressions from user-provided test cases.
 - [hurl](https://github.com/Orange-OpenSource/hurl) — Hurl, run and test HTTP requests with plain text.


### PR DESCRIPTION
Hi! Adding gity to `## Dev-Utilities`.

[gity](https://github.com/neul-labs/gity) is a cross-platform Rust daemon that accelerates Git on large repositories. It implements the Git `fsmonitor` v2 protocol, watches the working tree with native OS file watchers (inotify / FSEvents / ReadDirectoryChangesW), runs `git maintenance` during idle, and caches status results — so `git status` in a million-file repo returns in milliseconds.

- License: MIT
- Cross-platform: Linux, macOS, Windows
- Distributed via crates.io, npm (`gity-cli`), PyPI, Homebrew, and platform-native packages
- I am a maintainer of the project.