### PR TITLE
Add featherbar to System Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
 - [bottom](https://github.com/ClementTsang/bottom) — A customizable cross-platform graphical process/system monitor for the terminal.
 - [bpftop](https://github.com/Netflix/bpftop) – bpftop provides a dynamic real-time view of running eBPF programs.
 - [diskonaut](https://github.com/imsnif/diskonaut) — Terminal disk space navigator 🔭 .
+- [featherbar](https://github.com/nim444/featherbar) — A featherweight macOS menu-bar system monitor showing CPU, RAM, power, and temperature.
 - [netscanner](https://github.com/Chleba/netscanner) - All-in-one Network scanner.
 - [macchina](https://github.com/Macchina-CLI/macchina) — A system information frontend with an emphasis on performance.
 - [macmon](https://github.com/vladkens/macmon) - Sudoless performance / power monitoring for Apple Silicon processors.


### PR DESCRIPTION
[featherbar](https://github.com/nim444/featherbar) is a featherweight macOS menu-bar system monitor written in Rust (Apache-2.0). It shows CPU, RAM, power draw, and temperature in two color-coded menu bar lines, with zero background threads and flat ~20MB memory usage. Published on [crates.io](https://crates.io/crates/featherbar).

Added alphabetically to the System Monitor section.