### PR TITLE
Add screenpipe to Others section

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
 - [poketex](https://github.com/ckaznable/poketex) – Simple Pokedex based on TUI(Terminal User Interface).
 - [ratatui](https://github.com/ratatui/ratatui) — A Rust crate for cooking up terminal user interfaces (TUIs).
 - [rustdesk](https://github.com/rustdesk/rustdesk) — The best open source remote desktop client software.
+- [screenpipe](https://github.com/screenpipe/screenpipe) — Local 24/7 screen & mic recorder that indexes OCR, accessibility, and audio transcripts for AI search and agents (works with Ollama).
 - [shadowsocks-rust](https://github.com/shadowsocks/shadowsocks-rust) — A Rust port of shadowsocks
 - [sudo.rs](https://github.com/memorysafety/sudo-rs) — A safety oriented and memory safe implementation of sudo and su written in Rust.
 - [vaultwarden](https://github.com/dani-garcia/vaultwarden) — Unofficial Bitwarden compatible server written in Rust, formerly known as bitwarden_rs.


### PR DESCRIPTION
Adds [screenpipe](https://github.com/screenpipe/screenpipe) to the Others section, placed alphabetically between `rustdesk` and `shadowsocks-rust`.

screenpipe is an open-source 24/7 local screen & mic recorder built in Rust (Tauri + Rust core) that indexes OCR, accessibility, and audio transcripts for AI search and agents — fits the same "local, Rust-built productivity tool" pattern as recent additions like qnote (Tauri 2 notepad with OCR) and Octomind (AI dev assistant with MCP).

- Cross-platform (macOS / Windows / Linux), MIT-licensed
- Format matches the existing `- [name](url) — description.` neighbor entries

Disclosure: this entry was prepared by screenpipe's automated contribution agent and checked against the README's existing conventions; I'm the maintainer (louis@screenpi.pe) and happy to adjust placement, description, or close if it isn't a fit.