### PR TITLE
Add OpenTypeless

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
 - [inlyne](https://github.com/Inlyne-Project/inlyne) — A GPU powered yet browserless tool to help you quickly view markdown files in the blink of an eye.
 - [kanata](https://github.com/jtroo/kanata) - Improve keyboard comfort and usability with advanced customization.
 - [md-tui](https://github.com/henriklovhaug/md-tui) - A TUI application for viewing markdown files.
+- [OpenTypeless](https://github.com/tover0314-w/opentypeless) — Cross-platform AI voice typing desktop app built with Tauri.
 - [see](https://github.com/guilhermeprokisch/see) - A file visualization tool for terminal, offering advanced code viewing capabilities, Markdown rendering, and more. It provides syntax highlighting, emoji support, and image rendering capabilities, offering a visually appealing way to view various file types directly in your console.
 - [poketex](https://github.com/ckaznable/poketex) – Simple Pokedex based on TUI(Terminal User Interface).
 - [ratatui](https://github.com/ratatui/ratatui) — A Rust crate for cooking up terminal user interfaces (TUIs).


### PR DESCRIPTION
Adds OpenTypeless to the Others section.\n\nOpenTypeless is a cross-platform AI voice typing desktop app built with Tauri and a Rust backend.