### PR TITLE
Add Tura

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
 - [tlrc](https://github.com/tldr-pages/tlrc) — A tldr client written in Rust.
 - [tinty](https://github.com/tinted-theming/tinty) — A base16 and base24 color scheme manager.
 - [tokei](https://github.com/XAMPPRocky/tokei) — Count your code, quickly.
-- [Tura](https://github.com/Tura-AI/tura) — Local-first coding agent with graphical and terminal interfaces, project rules, checkpoints, and verification.
+- [Tura](https://github.com/Tura-AI/tura) — Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.
 - [ugdb](https://github.com/ftilde/ugdb) — An alternative TUI for gdb wrote in Rust.
 - [xsv](https://github.com/BurntSushi/xsv) — A fast CSV command line toolkit written in Rust.
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
 - [tlrc](https://github.com/tldr-pages/tlrc) — A tldr client written in Rust.
 - [tinty](https://github.com/tinted-theming/tinty) — A base16 and base24 color scheme manager.
 - [tokei](https://github.com/XAMPPRocky/tokei) — Count your code, quickly.
+- [Tura](https://github.com/Tura-AI/tura) — Local-first coding agent with graphical and terminal interfaces, project rules, checkpoints, and verification.
 - [ugdb](https://github.com/ftilde/ugdb) — An alternative TUI for gdb wrote in Rust.
 - [xsv](https://github.com/BurntSushi/xsv) — A fast CSV command line toolkit written in Rust.
 


### PR DESCRIPTION
## Summary

Adds [Tura](https://github.com/Tura-AI/tura) alphabetically to Dev-Utilities.

**Tura: 16.7% better performance, 77.5% fewer rounds.**

Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.

Benchmark details and reproducibility artifacts: https://turaai.net/benchmark

Tura is implemented in Rust and the change is limited to one README entry. `git diff --check` passes.

## Disclosure

I am affiliated with the Tura project. AI assistance was used to research the list and prepare this update; the final placement, links, claims, and diff were manually verified.