### PR TITLE
Add Edky to Dev-Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Harness the power of Rust. Those fast productivity tools based on Rust.
 - [dnspeep](https://github.com/jvns/dnspeep) – spy on the DNS queries your computer is making.
 - [dotter](https://github.com/SuperCuber/dotter) — A dotfile manager and templater written in rust 🦀.
 - [dtool](https://github.com/guoxbin/dtool) — A command-line tool collection to assist development.
+- [edky](https://github.com/artob/edky) - A command-line utility to convert Ed25519 public keys between various encoding formats (Base58, Base64, IPFS, iroh, libp2p, OpenSSH, etc).
 - [eva](https://github.com/nerdypepper/eva) – A calculator REPL, similar to bc(1).
 - [fnm](https://github.com/Schniz/fnm) — 🚀 Fast and simple Node.js version manager, built in Rust.
 - [forge](https://github.com/antinomyhq/forge) — A terminal-based AI pair programmer for software development, providing intelligent code assistance and collaboration features.


### PR DESCRIPTION
**[Edky] converts Ed25519 public keys between various encoding formats, such as Base16, Base58, Base64, etc.**

```shellsession
$ cargo binstall -y edky

$ edky convert -f hex -t base64url d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a
11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo

$ edky convert -f hex -t openssh d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINdamAGCsQq31Uv+08lkBzoO4XLz2qYjJa8CGmj3B1Ea
```

<img width="100%" alt="Showcase of edky convert" src="https://github.com/artob/edky/raw/master/rust/etc/asciinema/convert.gif"/>

[Edky]: https://github.com/artob/edky
